### PR TITLE
feat: use longer path first

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -512,13 +512,18 @@ class Router {
     return _leaveCurrentRoute(startingFrom, event);
   }
 
+  List _matchingRoutes(String path, Route baseRoute) {
+    return (baseRoute._routes.values.toList()
+      ..sort((r1, r2) => r1.path.compareTo(r2.path)))
+      .where((r) => r.path.match(path) != null).toList();
+  }
+
   Iterable<_Match> _matchingTreePath(String path, Route baseRoute) {
     List<_Match> treePath = <_Match>[];
     Route matchedRoute;
     do {
       matchedRoute = null;
-      List matchingRoutes = baseRoute._routes.values.where(
-          (r) => r.path.match(path) != null).toList();
+      List matchingRoutes = _matchingRoutes(path, baseRoute);
       if (!matchingRoutes.isEmpty) {
         if (matchingRoutes.length > 1) {
           _logger.warning("More than one route matches $path $matchingRoutes");

--- a/lib/url_matcher.dart
+++ b/lib/url_matcher.dart
@@ -5,7 +5,7 @@ import 'package:unittest/matcher.dart';
 /**
  * A reversible URL matcher interface.
  */
-abstract class UrlMatcher {
+abstract class UrlMatcher extends Comparable {
 
   /**
    * Attempts to match a given URL. If match is successul then returns an
@@ -23,6 +23,14 @@ abstract class UrlMatcher {
    * Returns a list of named parameters in the URL.
    */
   List<String> urlParameterNames();
+
+  /**
+   * Return a value which is:
+   * * negative if this matcher should be tested before another.
+   * * zero if this matcher and another can be tested in no particular order.
+   * * positive if this matcher should be tested after another.
+   */
+  int compareTo(Comparable another) => 0;
 }
 
 /**

--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -3,6 +3,7 @@ library url_template;
 import 'url_matcher.dart';
 
 final _specialChars = new RegExp(r'[\\\(\)\$\^\.\+\[\]\{\}\|]');
+final _paramPattern = r'([^/?]+)';
 
 /**
  * A reversible URL template class that can match/parse and reverse URL
@@ -15,6 +16,32 @@ class UrlTemplate implements UrlMatcher {
 
   String toString() {
     return '$_pattern';
+  }
+
+  int compareTo(Comparable matcher) {
+    final String tmpParamPattern = '\t';
+    if (matcher is UrlTemplate) {
+      String thisPattern = _pattern.pattern.replaceAll(_paramPattern, tmpParamPattern);
+      String thatPattern = matcher._pattern.pattern.replaceAll(_paramPattern, tmpParamPattern);
+      List<String> thisPatternParts = thisPattern.split('/');
+      List<String> thatPatternParts = thatPattern.split('/');
+      if (thisPatternParts.length == thatPatternParts.length) {
+        for (int i = 0; i < thisPatternParts.length; i++) {
+          String thisPart = thisPatternParts[i];
+          String thatPart = thatPatternParts[i];
+          if (thisPart == tmpParamPattern && thatPart != tmpParamPattern) {
+            return 1;
+          } else if (thisPart != tmpParamPattern && thatPart == tmpParamPattern) {
+            return -1;
+          }
+        }
+        return thatPattern.compareTo(thisPattern);
+      } else {
+        return thatPatternParts.length - thisPatternParts.length;
+      }
+    } else {
+      return 0;
+    }
   }
 
   UrlTemplate(String template) {
@@ -35,8 +62,8 @@ class UrlTemplate implements UrlMatcher {
       _fields.add(paramName);
       _chunks.add(txt);
       _chunks.add((Map params) => params != null ? params[paramName] : null);
-       sb.write(txt);
-      sb.write(r'([^/?]+)');
+      sb.write(txt);
+      sb.write(_paramPattern);
       start = m.end;
     });
     if (start != template.length) {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -22,6 +22,166 @@ main() {
     return router.route('/foo');
   });
 
+  group('use a longer path first', () {
+
+    test('add a longer path first', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'foobar',
+          path: '/foo/bar',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/foo/bar');
+            expect(router.root.getRoute('foobar').isActive, isTrue);
+          }))
+        ..addRoute(
+          name: 'foo',
+          path: '/foo',
+          enter: (e) => fail('should invoke /foo/bar'));
+      return router.route('/foo/bar');
+    });
+
+    test('add a longer path last', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'foo',
+          path: '/foo',
+          enter: (e) => fail('should invoke /foo/bar'))
+        ..addRoute(
+          name: 'foobar',
+          path: '/foo/bar',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/foo/bar');
+            expect(router.root.getRoute('foobar').isActive, isTrue);
+          }));
+      return router.route('/foo/bar');
+    });
+
+    test('add paths with a param', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'foo',
+          path: '/foo',
+          enter: (e) => fail('should invoke /foo/bar'))
+        ..addRoute(
+          name: 'fooparam',
+          path: '/foo/:param',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/foo/bar');
+            expect(router.root.getRoute('fooparam').isActive, isTrue);
+          }));
+      return router.route('/foo/bar');
+    });
+
+    test('add paths with a parametalized parent', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'paramaddress',
+          path: '/:zzzzzz/address',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/foo/address');
+            expect(router.root.getRoute('paramaddress').isActive, isTrue);
+          }))
+        ..addRoute(
+          name: 'param.add',
+          path: '/:aaaaaa/add',
+          enter: (e) => fail('should invoke /foo/address'));
+      return router.route('/foo/address');
+    });
+
+    test('add paths with a first param and one without', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'fooparam',
+          path: '/:param/foo',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/bar/foo');
+            expect(router.root.getRoute('fooparam').isActive, isTrue);
+          }))
+        ..addRoute(
+          name: 'bar',
+          path: '/bar',
+          enter: (e) => fail('should enter fooparam'));
+      return router.route('/bar/foo');
+    });
+
+    test('add paths with a first param and one without 2', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'paramfoo',
+          path: '/:param/foo',
+          enter: (e) => fail('should enter barfoo'))
+        ..addRoute(
+          name: 'barfoo',
+          path: '/bar/foo',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/bar/foo');
+            expect(router.root.getRoute('barfoo').isActive, isTrue);
+          }))
+        ;
+      return router.route('/bar/foo');
+    });
+
+    test('add paths with a second param and one without', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'bazparamfoo',
+          path: '/baz/:param/foo',
+          enter: (e) => fail('should enter bazbarfoo'))
+        ..addRoute(
+          name: 'bazbarfoo',
+          path: '/baz/bar/foo',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/baz/bar/foo');
+            expect(router.root.getRoute('bazbarfoo').isActive, isTrue);
+          }))
+        ;
+      return router.route('/baz/bar/foo');
+    });
+
+    test('add paths with a first param and a second param', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'parambarfoo',
+          path: '/:param/bar/foo',
+          enter: (e) => fail('should enter bazparamfoo'))
+        ..addRoute(
+          name: 'bazparamfoo',
+          path: '/baz/:param/foo',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/baz/bar/foo');
+            expect(router.root.getRoute('bazparamfoo').isActive, isTrue);
+          }))
+        ;
+      return router.route('/baz/bar/foo');
+    });
+
+    test('add paths with two params and a param', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+          name: 'param1param2foo',
+          path: '/:param1/:param2/foo',
+          enter: (e) => fail('should enter bazparamfoo'))
+        ..addRoute(
+          name: 'param1barfoo',
+          path: '/:param1/bar/foo',
+          enter: expectAsync((RouteEvent e) {
+            expect(e.path, '/baz/bar/foo');
+            expect(router.root.getRoute('param1barfoo').isActive, isTrue);
+          }))
+        ;
+      return router.route('/baz/bar/foo');
+    });
+  });
+
   group('hierarchical routing', () {
 
     _testParentChild(


### PR DESCRIPTION
This patch makes the following example (from the angular.js tutorial
step 7) work.

``` dart
router.root
  ..addRoute({
    'name': 'phonesList',
    'path': 'phones',
    'enter': (_) => ...
  })
  ..addRoute({
    'name': 'phoneDetail',
    'path': 'phones/:phoneId',
    'enter': (_) => ...
  });
```

see: https://github.com/angular/angular.dart/pull/533
