### PR TITLE
feat(test): Add support for travis (closes #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 packages
 pubspec.lock
 .buildlog
+build/
 example/full/out
+/node_modules/
+/test/out/
+/npm-debug.log
+.DS_Store
+dart-sdk
+dartium

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: node_js
+node_js:
+  - 0.10
+
+env:
+  matrix:
+    - JOB=unit-stable
+    - JOB=unit-dev
+  global:
+    - CHROME_BIN=/usr/bin/google-chrome
+
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - "sudo apt-get update -qq"
+  - "sudo apt-get install -qq unzip chromium-browser"
+  - "sudo apt-get install libxss1"
+  - "wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+  - "sudo dpkg -i google-chrome*.deb"
+  - "sudo chmod u+s /opt"
+
+
+before_script:
+  - ./test/scripts/travis-setup.sh
+
+script:
+  - ./test/scripts/travis-build.sh

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,39 @@
+module.exports = function(config) {
+  config.set({
+    //logLevel: config.LOG_DEBUG,
+    basePath: '.',
+    frameworks: ['dart-unittest'],
+
+    // list of files / patterns to load in the browser
+    // all tests must be 'included', but all other libraries must be 'served' and
+    // optionally 'watched' only.
+    files: [
+      'test/*.dart',
+      {pattern: '**/*.dart', watched: true, included: false, served: true},
+      'packages/browser/dart.js',
+      'packages/browser/interop.js'
+    ],
+
+    autoWatch: false,
+
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 5000,
+
+    plugins: [
+      'karma-dart',
+      'karma-chrome-launcher',
+      'karma-script-launcher',
+      'karma-junit-reporter'
+    ],
+
+    customLaunchers: {
+      Dartium: { base: 'ChromeCanary', flags: ['--no-sandbox'] },
+      ChromeNoSandbox: { base: 'Chrome', flags: ['--no-sandbox'] }
+    },
+
+    junitReporter: {
+      outputFile: 'test/out/unit.xml',
+      suite: 'unit'
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "route.dart",
+  "branchVersion": "0.4.*",
+  "cdnVersion": "0.9.14",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/route.dart.git"
+  },
+  "devDependencies": {
+    "karma" : "0.10.2",
+    "karma-dart" : "0.2.6",
+    "karma-script-launcher": "*",
+    "karma-chrome-launcher": "*",
+    "karma-firefox-launcher": "*",
+    "karma-junit-reporter": "0.1.0",
+    "jasmine-node": "*",
+    "qq": "*"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/angular/route.dart/blob/master/LICENSE"
+    }
+  ],
+  "dependencies": {}
+}

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,3 +1,9 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library route.client_test;
+
 import 'dart:async';
 
 import 'package:unittest/unittest.dart';
@@ -5,7 +11,7 @@ import 'package:unittest/mock.dart';
 import 'package:route_hierarchical/client.dart';
 import 'package:route_hierarchical/url_pattern.dart';
 
-import 'mocks.dart';
+import 'util/mocks.dart';
 
 main() {
   unittestConfiguration.timeout = new Duration(seconds: 1);

--- a/test/pattern_test.dart
+++ b/test/pattern_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+library route.pattern_test;
 
 import 'package:unittest/unittest.dart';
 import 'package:route_hierarchical/pattern.dart';

--- a/test/scripts/env.sh
+++ b/test/scripts/env.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+if [ -n "$DART_SDK" ]; then
+    DARTSDK=$DART_SDK
+else
+    echo "sdk=== $DARTSDK"
+    DART=`which dart|cat` # pipe to cat to ignore the exit code
+    DARTSDK=`which dart | sed -e 's/\/dart\-sdk\/.*$/\/dart-sdk/'`
+
+    if [ "$DARTSDK" = "/Applications/dart/dart-sdk" ]; then
+        # Assume we are a mac machine with standard dart setup
+        export DARTIUM="/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium"
+    else
+        DARTSDK="`pwd`/dart-sdk"
+        case $( uname -s ) in
+          Darwin)
+            export DARTIUM=${DARTIUM:-./dartium/Chromium.app/Contents/MacOS/Chromium}
+            ;;
+          Linux)
+            export DARTIUM=${DARTIUM:-./dartium/chrome}
+            ;;
+        esac
+    fi
+fi
+
+export DART_SDK="$DARTSDK"
+export DART=${DART:-"$DARTSDK/bin/dart"}
+export PUB=${PUB:-"$DARTSDK/bin/pub"}
+export DARTANALYZER=${DARTANALYZER:-"$DARTSDK/bin/dartanalyzer"}
+export DARTDOC=${DARTDOC:-"$DARTSDK/bin/dartdoc"}
+export DART_DOCGEN=${DART_DOCGEN:-"$DARTSDK/bin/docgen"}
+
+export CHROME_CANARY_BIN=${CHROME_CANARY_BIN:-"$DARTIUM"}
+export CHROME_BIN=${CHROME_BIN:-"google-chrome"}
+export DART_FLAGS='--enable_type_checks --enable_asserts'
+export PATH=$PATH:$DARTSDK/bin

--- a/test/scripts/travis-build.sh
+++ b/test/scripts/travis-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -evx
+. ./test/scripts/env.sh
+
+node "node_modules/karma/bin/karma" start karma.conf \
+  --reporters=junit,dots --port=8765 --runner-port=8766 \
+  --browsers=Dartium,ChromeNoSandbox --single-run --no-colors
+

--- a/test/scripts/travis-setup.sh
+++ b/test/scripts/travis-setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+case $( uname -s ) in
+  Linux)
+    DART_SDK_ZIP=dartsdk-linux-x64-release.zip
+    DARTIUM_ZIP=dartium-linux-x64-release.zip
+    ;;
+  Darwin)
+    DART_SDK_ZIP=dartsdk-macos-x64-release.zip
+    DARTIUM_ZIP=dartium-macos-ia32-release.zip
+    ;;
+esac
+
+CHANNEL=`echo $JOB | cut -f 2 -d -`
+echo Fetch Dart channel: $CHANNEL
+
+echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP
+curl http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP > $DART_SDK_ZIP
+echo Fetched new dart version $(unzip -p $DART_SDK_ZIP dart-sdk/version)
+rm -rf dart-sdk
+unzip $DART_SDK_ZIP > /dev/null
+rm $DART_SDK_ZIP
+
+echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/latest/dartium/$DARTIUM_ZIP
+curl http://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/latest/dartium/$DARTIUM_ZIP > $DARTIUM_ZIP
+unzip $DARTIUM_ZIP > /dev/null
+rm -rf dartium
+rm $DARTIUM_ZIP
+mv dartium-* dartium
+
+echo =============================================================================
+. ./test/scripts/env.sh
+$DART --version
+$PUB install

--- a/test/url_pattern_test.dart
+++ b/test/url_pattern_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
 library route.url_pattern_test;
 
 import 'package:unittest/unittest.dart';

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -1,4 +1,4 @@
-library url_template_test;
+library route.url_template_test;
 
 import 'package:unittest/unittest.dart';
 import 'package:route_hierarchical/url_template.dart';

--- a/test/util/mocks.dart
+++ b/test/util/mocks.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library test_mocks;
+library route.test_mocks;
 
 import 'dart:html';
 import 'package:unittest/mock.dart';


### PR DESCRIPTION
Most files are adapted from angular.dart.

Test [pass](https://travis-ci.org/vicb/route.dart/builds/19569213) on Travis.
