### PR TITLE
Fixes for unittest deprecations

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,13 @@
-name:  route_hierarchical
-description:  A client routing library for Dart
-version: 0.4.15
+name: route_hierarchical
+version: 0.4.16-dev
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Pavel Jbanov <pavelj@google.com>
+description: A client routing library for Dart
 homepage: https://github.com/angular/route.dart
-
 dependencies:
   browser: any
   logging: any
-
 dev_dependencies:
-  unittest: any
+  mock: '>=0.10.0 <0.11.0'
+  unittest: '>=0.10.0 <0.11.0'

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -7,7 +7,7 @@ library route.client_test;
 import 'dart:async';
 
 import 'package:unittest/unittest.dart';
-import 'package:unittest/mock.dart';
+import 'package:mock/mock.dart';
 import 'package:route_hierarchical/client.dart';
 import 'package:route_hierarchical/url_pattern.dart';
 

--- a/test/util/mocks.dart
+++ b/test/util/mocks.dart
@@ -5,7 +5,7 @@
 library route.test_mocks;
 
 import 'dart:html';
-import 'package:unittest/mock.dart';
+import 'package:mock/mock.dart';
 
 class MockWindow extends Mock implements Window {
   final history = new MockHistory();


### PR DESCRIPTION
mock was moved to its own package.

Added dependency constraints to mock and unittest

Bumped the version to 0.4.16-dev
