### PR TITLE
issue #40 route always emptied title field with no reason - title is no ...

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -714,14 +714,13 @@ class Router {
       });
 
   void _go(String path, String title, bool replace) {
-    if (title == null) title =  '';
     if (_useFragment) {
       if (replace) {
         _window.location.replace('#$path');
       } else {
         _window.location.assign('#$path');
       }
-      (_window.document as HtmlDocument).title = title;
+      if (title != null)(_window.document as HtmlDocument).title = title;
     } else {
       if (replace) {
         _window.history.replaceState(null, title, path);


### PR DESCRIPTION
...longer touched

To avoid that angular interferes with the apps title it is no longer removed. Currently there seem to be preparations to solve issue #10 which asks to set the title on a per route basis, which is a good idea, but the old code breaks applications that try to set the title by themselves. (Or at least produces unnecessary work, by removing the title)

My patch solves that by only setting the title when it is actually provided, so you should have no effort when the title handling is really implemented.
