### PR TITLE
Nested scope is destroyed 2 times because of nesting routing leave order

### DIFF
--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -239,6 +239,25 @@ main() {
 
   group('leave', () {
 
+    test('should leave children when parent selected', () {
+      var router = new Router();
+      String currentPathStr(Router router) => router.activePath.map((r) => r.name).join("+");
+      router.root
+        ..addRoute(path: '/parent',
+            name: 'parent',
+            leave: (_) => logMessage("parent leave"),
+            mount: (Route route) => route
+              ..addRoute(path: '/child',
+                  leave: (_) => logMessage("child leave"),
+                  name: 'child'));
+      router.route('/parent/child').then((_) {
+        expect(currentPathStr(router),"parent+child");
+        router.route('/parent').then((_) {
+          expect(currentPathStr(router),"parent");
+        });
+      });
+    });
+    
     test('should leave previous route and enter new', () {
       var counters = <String, int>{
         'otherPreEnter': 0,


### PR DESCRIPTION
I change a nested routing structure, and I am getting this error:
#0 Scope.destroy (package:angular/core/scope.dart:295:12)
#1 NgView._cleanUp (package:angular/routing/ng_view.dart:141:19)
#2 NgView._show.(package:angular/routing/ng_view.dart:114:15)

The reason is that parent routing leave is detaching the ng-view.

I change the leave test (in the pullrequest), to check the order of leave callback execution. For routing like this
Parent -> Child
the current execution is
Parent.leave and then Child.leave

It should be Child.leave and then Parent.leave.
