### PR TITLE
refactor(UrlMatcher): Make UrlMatcher.urlParameterNames a getter

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -291,7 +291,7 @@ class RouteImpl extends Route {
     parameters.keys.forEach((String prefixedKey) {
       if (prefixedKey.startsWith('${route.name}.')) {
         var key = prefixedKey.substring('${route.name}.'.length);
-        if (!route.path.urlParameterNames().contains(key)) {
+        if (!route.path.urlParameterNames.contains(key)) {
           queryParams[prefixedKey] = parameters[prefixedKey];
         }
       }

--- a/lib/url_matcher.dart
+++ b/lib/url_matcher.dart
@@ -21,7 +21,7 @@ abstract class UrlMatcher extends Comparable<UrlMatcher> {
   /**
    * Returns a list of named parameters in the URL.
    */
-  List<String> urlParameterNames();
+  List<String> get urlParameterNames;
 
   /**
    * Returns a value which is:

--- a/lib/url_pattern.dart
+++ b/lib/url_pattern.dart
@@ -287,7 +287,7 @@ class UrlPattern implements UrlMatcher, Pattern {
     throw new UnimplementedError('matchAsPrefix is not implemented');
   }
 
-  List<String> urlParameterNames() {
+  List<String> get urlParameterNames {
     throw new UnimplementedError('urlParameterNames is not implemented');
   }
 

--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -89,5 +89,5 @@ class UrlTemplate implements UrlMatcher {
   String reverse({Map parameters, String tail: ''}) =>
     _chunks.map((c) => c is Function ? c(parameters) : c).join() + tail;
 
-  List<String> urlParameterNames() => _fields;
+  List<String> get urlParameterNames => _fields;
 }


### PR DESCRIPTION
Before:

```
var names = matcher.urlParameterNames();
```

After:

```
var names = matcher.urlParameterNames;
```
