### PR TITLE
perf: change StringBuffer for String

### DIFF
--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -53,7 +53,7 @@ class UrlTemplate implements UrlMatcher {
     _fields = <String>[];
     _chunks = [];
     var exp = new RegExp(r':(\w+)');
-    StringBuffer sb = new StringBuffer('^');
+    _strPattern = '^';
     int start = 0;
     exp.allMatches(template).forEach((Match m) {
       var paramName = m.group(1);
@@ -61,16 +61,14 @@ class UrlTemplate implements UrlMatcher {
       _fields.add(paramName);
       _chunks.add(txt);
       _chunks.add((Map params) => params != null ? params[paramName] : null);
-      sb.write(txt);
-      sb.write(_paramPattern);
+      _strPattern += txt + _paramPattern;
       start = m.end;
     });
     if (start != template.length) {
       var txt = template.substring(start, template.length);
-      sb.write(txt);
+      _strPattern +=  txt;
       _chunks.add(txt);
     }
-    _strPattern = sb.toString();
     _pattern = new RegExp(_strPattern);
   }
 


### PR DESCRIPTION
```
const _LEN = 50000;

sb() {
  var sw = new Stopwatch()..start();

  for (var j = 0; j < _LEN; j++) {
    var sb = new StringBuffer("a");
    sb.write("b");
    sb.write("c");
    sb.write("d");
    sb.write("e");
    sb.write("f");
    sb.toString();
  }

  sw.stop();
  print("sb: ${sw.elapsedMicroseconds / 1000}");
}

direct() {
  var sw = new Stopwatch()..start();

  for (var j = 0; j < _LEN; j++) {
    String sb = "a";
    sb += "b";
    sb += "c";
    sb += "d";
    sb += "e";
    sb += "f";
  }

  sw.stop();
  print("string: ${sw.elapsedMicroseconds / 1000}");
}

main() {
  sb();
  direct();
}
```

sb: 34.648
string: 26.487
