### PR TITLE
Permit routes with slashes

### DIFF
--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -4,6 +4,7 @@ import 'url_matcher.dart';
 
 final _specialChars = new RegExp(r'[\\()$^.+[\]{}|]');
 final _paramPattern = r'([^/?]+)';
+final _paramWithSlashesPattern = r'([^?]+)';
 
 /**
  * A reversible URL template class that can match/parse and reverse URL
@@ -52,7 +53,7 @@ class UrlTemplate implements UrlMatcher {
         replaceAllMapped(_specialChars, (m) => r'\' + m.group(0));
     _fields = <String>[];
     _chunks = [];
-    var exp = new RegExp(r':(\w+)');
+    var exp = new RegExp(r':(\w+\*?)');
     StringBuffer sb = new StringBuffer('^');
     int start = 0;
     exp.allMatches(template).forEach((Match m) {
@@ -62,7 +63,11 @@ class UrlTemplate implements UrlMatcher {
       _chunks.add(txt);
       _chunks.add((Map params) => params != null ? params[paramName] : null);
       sb.write(txt);
-      sb.write(_paramPattern);
+      if (paramName.endsWith(r'*')) {
+        sb.write(_paramWithSlashesPattern);
+      } else {
+        sb.write(_paramPattern);
+      }
       start = m.end;
     });
     if (start != template.length) {

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -91,5 +91,25 @@ main() {
         'c': 'baz',
       }), '/foo/bar/baz/tail');
     });
+
+    test('should conditionally allow slashes in parameters', () {
+      var tmpl = new UrlTemplate('/foo/:bar');
+            expect(tmpl.match('/foo/123/456'),
+                new UrlMatch('/foo/123', '/456', {
+                  'bar': '123'
+                }));
+
+      tmpl = new UrlTemplate('/foo/:bar*');
+      expect(tmpl.match('/foo/123/456'),
+          new UrlMatch('/foo/123/456', '', {
+            'bar*': '123/456'
+          }));
+
+      tmpl = new UrlTemplate('/foo/:bar*/baz');
+      expect(tmpl.match('/foo/123/456/baz'),
+          new UrlMatch('/foo/123/456/baz', '', {
+            'bar*': '123/456'
+          }));
+    });
   });
 }


### PR DESCRIPTION
Allow route parameters with slashes in them, if the param name has a trailing * character.