### PR TITLE
test(travis): fix the installation of Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - "sudo apt-get update -qq"
   - "sudo apt-get install -qq unzip chromium-browser"
   - "sudo apt-get install libxss1"
+  - "sudo apt-get install libappindicator1"
   - "wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
   - "sudo dpkg -i google-chrome*.deb"
   - "sudo chmod u+s /opt"


### PR DESCRIPTION
Closes #60

Travis tests were failing during the installation of chrome due to a missing dependency (libappindicator1)
