### PR TITLE
Permit routes with slashes

### DIFF
--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -4,6 +4,7 @@ import 'url_matcher.dart';
 
 final _specialChars = new RegExp(r'[\\()$^.+[\]{}|]');
 final _paramPattern = r'([^/?]+)';
+final _paramWithSlashesPattern = r'([^?]+)';
 
 /**
  * A reversible URL template class that can match/parse and reverse URL
@@ -65,7 +66,7 @@ class UrlTemplate implements UrlMatcher {
     template = template.replaceAllMapped(_specialChars, (m) => r'\' + m[0]);
     _fields = <String>[];
     _chunks = [];
-    var exp = new RegExp(r':(\w+)');
+    var exp = new RegExp(r':(\w+\*?)');
     StringBuffer sb = new StringBuffer('^');
     int start = 0;
     exp.allMatches(template).forEach((Match m) {
@@ -75,7 +76,11 @@ class UrlTemplate implements UrlMatcher {
       _chunks.add(txt);
       _chunks.add((Map params) => params[paramName]);
       sb.write(txt);
-      sb.write(_paramPattern);
+      if (paramName.endsWith(r'*')) {
+        sb.write(_paramWithSlashesPattern);
+      } else {
+        sb.write(_paramPattern);
+      }
       start = m.end;
     });
     if (start != template.length) {

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -91,5 +91,24 @@ main() {
         'c': 'baz',
       }), '/foo/bar/baz/tail');
     });
+    test('should conditionally allow slashes in parameters', () {
+      var tmpl = new UrlTemplate('/foo/:bar');
+      expect(tmpl.match('/foo/123/456'),
+      new UrlMatch('/foo/123', '/456', {
+          'bar': '123'
+      }));
+
+      tmpl = new UrlTemplate('/foo/:bar*');
+      expect(tmpl.match('/foo/123/456'),
+      new UrlMatch('/foo/123/456', '', {
+          'bar*': '123/456'
+      }));
+
+      tmpl = new UrlTemplate('/foo/:bar*/baz');
+      expect(tmpl.match('/foo/123/456/baz'),
+      new UrlMatch('/foo/123/456/baz', '', {
+          'bar*': '123/456'
+      }));
+    });url_template.dart
   });
 }

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -109,6 +109,6 @@ main() {
       new UrlMatch('/foo/123/456/baz', '', {
           'bar*': '123/456'
       }));
-    });url_template.dart
+    });
   });
 }


### PR DESCRIPTION
Updating https://github.com/angular/route.dart/pull/55 to be based off of route_hierarchical 0.5.0
