### PR TITLE
chore(cleanup): get rid of warnings

### DIFF
--- a/test/all_web_tests.dart
+++ b/test/all_web_tests.dart
@@ -1,13 +1,11 @@
-import "client_test.dart" as client_test;
-import "url_template_test.dart" as url_template_test;
 import "click_handler_test.dart" as click_handler_test;
+import "client_test.dart" as client_test;
 import "link_matcher_test.dart" as link_matcher_test;
 import "url_template_test.dart" as url_template_test;
 
 main() {
-  client_test.main();
-  url_template_test.main();
   click_handler_test.main();
+  client_test.main();
   link_matcher_test.main();
   url_template_test.main();
 }

--- a/test/click_handler_test.dart
+++ b/test/click_handler_test.dart
@@ -1,4 +1,4 @@
-library route.link_matcher_test;
+library route.click_handler_test;
 
 import 'dart:html';
 import 'dart:async';


### PR DESCRIPTION
* Remove duplicated library name
* Remove duplicated library import
* Do not run url_template_tests twice