### PR TITLE
move the browser package to a dev_dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ authors:
 description: A client routing library for Dart
 homepage: https://github.com/angular/route.dart
 dependencies:
-  browser: any
   logging: any
 dev_dependencies:
+  browser: any
   mock: '>=0.10.0 <0.11.0'
   unittest: '>=0.10.0 <0.11.0'


### PR DESCRIPTION
Move the `browser` package dep from `dependencies` to `dev_dependencies`.