### PR TITLE
Improve support for URL query parameters

### DIFF
--- a/lib/click_handler.dart
+++ b/lib/click_handler.dart
@@ -48,14 +48,19 @@ class DefaultWindowClickHandler {
     if (!_linkMatcher.matches(anchor)) {
       return;
     }
+
     if (anchor.host == _window.location.host) {
+      e.preventDefault();
       if (_useFragment) {
-        e.preventDefault();
         _router.gotoUrl(_normalizer(anchor.hash));
-      } else if (anchor.pathname != _window.location.pathname ||
-                 anchor.search != _window.location.search) {
-        e.preventDefault();
-        _router.gotoUrl('${anchor.pathname}${anchor.search}${anchor.hash}');
+      } else if (anchor.hash == '') {
+        _router.gotoUrl('${anchor.pathname}${anchor.search}');
+      } else {
+        Element el = document.querySelector(anchor.hash);
+        if (el != null) {
+          Rectangle r = el.getBoundingClientRect();
+          _window.scroll(0, r.top.floor());
+        }
       }
     }
   }

--- a/lib/click_handler.dart
+++ b/lib/click_handler.dart
@@ -49,9 +49,14 @@ class DefaultWindowClickHandler {
       return;
     }
     if (anchor.host == _window.location.host) {
-      e.preventDefault();
-      _router.gotoUrl(
-          _useFragment ? _normalizer(anchor.hash) : '${anchor.pathname}');
+      if (_useFragment) {
+        e.preventDefault();
+        _router.gotoUrl(_normalizer(anchor.hash));
+      } else if (anchor.pathname != _window.location.pathname ||
+                 anchor.search != _window.location.search) {
+        e.preventDefault();
+        _router.gotoUrl('${anchor.pathname}${anchor.search}${anchor.hash}');
+      }
     }
   }
 }

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -810,7 +810,8 @@ class Router {
       route(_normalizeHash(_window.location.hash));
     } else {
       String getPath() =>
-          '${_window.location.pathname}${_window.location.search}${_window.location.hash}';
+          '${_window.location.pathname}${_window.location.search}'
+          '${_window.location.hash}';
 
       _window.onPopState.listen((_) {
         route(getPath()).then((allowed) {

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -810,7 +810,7 @@ class Router {
       route(_normalizeHash(_window.location.hash));
     } else {
       String getPath() =>
-          '${_window.location.pathname}${_window.location.hash}';
+          '${_window.location.pathname}${_window.location.search}${_window.location.hash}';
 
       _window.onPopState.listen((_) {
         route(getPath()).then((allowed) {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1691,12 +1691,15 @@ main() {
 
       testInit(mockWindow, [count = 1]) {
         mockWindow.location.when(callsTo('get hash')).alwaysReturn('');
-        mockWindow.location.when(callsTo('get pathname')).alwaysReturn('/foo');
+        mockWindow.location.when(callsTo('get pathname')).alwaysReturn('/hello');
+        mockWindow.location.when(callsTo('get search')).alwaysReturn('?foo=bar&baz=bat');
         var router = new Router(useFragment: false, windowImpl: mockWindow);
-        router.root.addRoute(name: 'foo', path: '/foo');
+        router.root.addRoute(name: 'hello', path: '/hello');
         router.onRouteStart.listen(expectAsync((RouteStartEvent start) {
           start.completed.then(expectAsync((_) {
-            expect(router.findRoute('foo').isActive, isTrue);
+            expect(router.findRoute('hello').isActive, isTrue);
+            expect(router.findRoute('hello').queryParameters['baz'], 'bat');
+            expect(router.findRoute('hello').queryParameters['foo'], 'bar');
           }));
         }, count: count));
         router.listen(ignoreClick: true);


### PR DESCRIPTION
Route.dart's support for query parameters, e.g. `?foo=bar&baz=bat` is abysmal.

* Doesn't preserve query parameters on initial page load. (See #78)
* Doesn't preserve query parameters in anchor element. (See #95)
* Doesn't preserve query parameters for `onpopstate` events. (No issue opened.)
* Can't use hash for scrolling to anchor in HTML5 mode. (See #86)

I spent almost 3 full days trying to hack around all of its idiosyncracies and finally gave up in frustration. It turns out to be much easier just to fix route.dart.

**Caveats**

1. I've focused on HTML5 mode, because I don't know enough about routing with the URL fragment to do it right.
2. I started to write a unit test for the click handler but it complains that `MockWindow` doesn't have an `onPopState` member, and it seems like a lot of work to properly mock `onPopState`. There are no existing tests for HTML5 routing that I can mimic — the tests are exclusively for fragment routing.
