### PR TITLE
Added method returning all sub-routes of a Route object

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -157,7 +157,7 @@ abstract class Route {
   /**
    * Returns all sub-routes associated with this route
    *
-   * If routes has no sub-routes then null is returned.
+   * If route has no sub-routes then null is returned.
    */
   Map getSubRoutes();
 
@@ -291,12 +291,12 @@ class RouteImpl extends Route {
 
   @override
   Map<String, Route> getSubRoutes(){
-    if (_routes.isEmpty) {
+    Map<String, RouteImpl> _currentSubRoutes = _routes;
+    if (_currentSubRoutes.isEmpty) {
       return null;
     }
-    return _routes;
+    return _currentSubRoutes;
   }
-
 
   String _getHead(String tail) {
     for (RouteImpl route = this; route.parent != null; route = route.parent) {

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -123,6 +123,8 @@ abstract class Route {
    */
   Stream<RouteEnterEvent> get onEnter;
 
+
+
   void addRoute({String name, Pattern path, bool defaultRoute: false,
         RouteEnterEventHandler enter, RoutePreEnterEventHandler preEnter,
         RoutePreLeaveEventHandler preLeave, RouteLeaveEventHandler leave,
@@ -151,6 +153,13 @@ abstract class Route {
    * If no match is found then null is returned.
    */
   Route findRoute(String routePath);
+
+  /**
+   * Returns all sub-routes associated with this route
+   *
+   * If routes has no sub-routes then null is returned.
+   */
+  Map getSubRoutes();
 
   /**
    * Create an return a new [RouteHandle] for this route.
@@ -279,6 +288,15 @@ class RouteImpl extends Route {
     }
     return currentRoute;
   }
+
+  @override
+  Map<String, Route> getSubRoutes(){
+    if (_routes.isEmpty) {
+      return null;
+    }
+    return _routes;
+  }
+
 
   String _getHead(String tail) {
     for (RouteImpl route = this; route.parent != null; route = route.parent) {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -29,7 +29,7 @@ main() {
   });
 
   test('sub-routes added with addRoute are returned', () {
-    Router router = new Router();
+    var router = new Router();
     router.root
     ..addRoute(
         name: 'foo',
@@ -39,9 +39,13 @@ main() {
         name: 'bar',
         path: '/bar'
     );
-    expect(router.root.getSubRoutes().isNotEmpty, isTrue);
-    expect(router.root.getSubRoutes().containsKey('/foo') &&
-           router.root.getSubRoutes().containsKey('/bar'), isTrue);
+    expect(router.root.getSubRoutes().containsKey('foo'), isTrue);
+    expect(router.root.getSubRoutes().containsKey('bar'), isTrue);
+  });
+
+  test('getSubRoutes returns null if map is empty', () {
+    var router = new Router();
+    expect(router.root.getSubRoutes(), isNull);
   });
 
   group('use a longer path first', () {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -28,6 +28,22 @@ main() {
     return router.route('/foo');
   });
 
+  test('sub-routes added with addRoute are returned', () {
+    Router router = new Router();
+    router.root
+    ..addRoute(
+        name: 'foo',
+        path: '/foo'
+    )
+    ..addRoute(
+        name: 'bar',
+        path: '/bar'
+    );
+    expect(router.root.getSubRoutes().isNotEmpty, isTrue);
+    expect(router.root.getSubRoutes().containsKey('/foo') &&
+           router.root.getSubRoutes().containsKey('/bar'), isTrue);
+  });
+
   group('use a longer path first', () {
 
     test('add a longer path first', () {


### PR DESCRIPTION
An easy way to get all sub-routes of a Route was missing.
This PR adds it to abstract class Route and its implementation.
Tests pass in current content-shell full-stable-45692.0.