### PR TITLE
URL decode/encode parameters.

### DIFF
--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -107,6 +107,13 @@ class UrlTemplate implements UrlMatcher {
   String reverse({Map parameters, String tail: ''}) {
     if (parameters == null) {
       parameters = const {};
+    } else {
+      parameters = new Map.from(parameters);
+      parameters.forEach((String key, String value) {
+        parameters[key] = key.endsWith('*')
+            ? value.splitMapJoin('/', onNonMatch: Uri.encodeComponent)
+            : Uri.encodeComponent(value);
+      });
     }
     return _chunks.map((c) => c is Function ? c(parameters) : c).join() + tail;
   }

--- a/lib/url_template.dart
+++ b/lib/url_template.dart
@@ -98,7 +98,7 @@ class UrlTemplate implements UrlMatcher {
     }
     var parameters = new Map();
     for (var i = 0; i < match.groupCount; i++) {
-      parameters[_fields[i]] = match[i + 1];
+      parameters[_fields[i]] = Uri.decodeComponent(match[i + 1]);
     }
     var tail = url.substring(match[0].length);
     return new UrlMatch(match[0], tail, parameters);

--- a/test/url_template_test.dart
+++ b/test/url_template_test.dart
@@ -53,6 +53,16 @@ main() {
           }));
     });
 
+    test('should decode parameters', () {
+      var tmpl = new UrlTemplate(r'/:a/:o/:u');
+      expect(tmpl.match(r'/%C3%A4/%C3%B6/%C3%BC'),
+          new UrlMatch(r'/%C3%A4/%C3%B6/%C3%BC', '', {
+            'a': 'ä',
+            'o': 'ö',
+            'u': 'ü'
+          }));
+    });
+
     test('should only match prefix', () {
       var tmpl = new UrlTemplate(r'/foo');
       expect(tmpl.match(r'/foo/foo/bar'),
@@ -78,7 +88,7 @@ main() {
       expect(tmpl.reverse(), 'null/bar/baz');
       expect(tmpl.reverse(parameters: {
         'a': '/foo',
-      }), '/foo/bar/baz');
+      }), '%2Ffoo/bar/baz');
 
       tmpl = new UrlTemplate('/foo/bar/:c');
       expect(tmpl.reverse(), '/foo/bar/null');
@@ -98,18 +108,30 @@ main() {
           new UrlMatch('/foo/123', '/456', {
               'bar': '123'
           }));
+      expect(tmpl.reverse(tail: '/456', parameters: {
+              'bar': '123'
+          }), '/foo/123/456');
+      expect(tmpl.reverse(parameters: {
+              'bar': '123/456'
+          }), '/foo/123%2F456');
 
       tmpl = new UrlTemplate('/foo/:bar*');
       expect(tmpl.match('/foo/123/456'),
           new UrlMatch('/foo/123/456', '', {
               'bar*': '123/456'
           }));
+      expect(tmpl.reverse(parameters: {
+              'bar*': '123/456'
+          }), '/foo/123/456');
 
       tmpl = new UrlTemplate('/foo/:bar*/baz');
       expect(tmpl.match('/foo/123/456/baz'),
           new UrlMatch('/foo/123/456/baz', '', {
               'bar*': '123/456'
           }));
+      expect(tmpl.reverse(parameters: {
+              'bar*': '123/456'
+          }), '/foo/123/456/baz');
     });
   });
 }


### PR DESCRIPTION
I am currently building a server application using the `redstone` framework which utilizes the `UrlTemplate` class of this package. 
I've noticed difficulties handling requests containing special characters like slashes and spaces as well as most Unicode characters outside the Latin alphabet. This is because the browser [percent-encodes][wiki] such characters as they either are reserved or not allowed by [RFC 3986][rfc].

The URL `/foo/bar baz/qux` is therefore encoded as `/foo/bar%20baz/qux`. When matched against the template `/foo/:param/qux` it thus yields `{'param': 'bar%20baz'}` instead of `{'param': 'bar baz'}`.
I could not find any documentation or tests verifying that this behavior is intended and I think that most users probably don't expect these results plus decoding all parameters manually would be annoying.

To solve this issue `UrlTemplate.match` should decode all matched parameters and `UrlTemplate.reverse` should encode them.
As parameters ending with `'*'` are allowed to contain forward slashes only the slash separated parts of such parameters must be encoded.

I've included some tests, but had to update one of the expectations of the `should reverse` test.

```dart
tmpl = new UrlTemplate(':a/bar/baz');
expect(tmpl.reverse(), 'null/bar/baz');
expect(tmpl.reverse(parameters: {
  'a': '/foo',
}), '/foo/bar/baz');
```

Because `'a'` does not end with `'*'` the leading slash has literal meaning and must be encoded as `'%2F'`.
I don't think that this is actually a problem because `':a/bar/baz'` does not match `'/foo/bar/baz'` anyway even though `tmpl.match(tmpl.reverse(...))` should never be `null`.

[wiki]: https://en.wikipedia.org/wiki/Percent-encoding "Percent-encoding - Wikipedia, the free encyclopedia"
[rfc]: https://tools.ietf.org/html/rfc3986#section-2 "RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax"